### PR TITLE
Set CORS headers on redirect

### DIFF
--- a/content/en/admin/config.md
+++ b/content/en/admin/config.md
@@ -29,6 +29,9 @@ To install Mastodon on `mastodon.example.com` in such a way it can serve `@alice
 
 ```
 location /.well-known/webfinger {
+  add-header Access-Control-Allow-Methods GET;
+  add-header Access-Control-Allow-Origin "*";
+  add-header Access-Control-Max-Age 7200;
   return 301 https://mastodon.example.com$request_uri;
 }
 ```


### PR DESCRIPTION
This allows the API to be used from a web page, even when WEB_DOMAIN is different from LOCAL_DOMAIN.